### PR TITLE
Speedup - Inspired by the 1.12 version

### DIFF
--- a/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
@@ -58,8 +58,8 @@ public class MineTweakerImplementationAPI {
     private static final ListenPlayerLoggedIn LISTEN_LOGIN = new ListenPlayerLoggedIn();
     private static final ListenPlayerLoggedOut LISTEN_LOGOUT = new ListenPlayerLoggedOut();
     private static final ListenBlockInfo LISTEN_BLOCK_INFO = new ListenBlockInfo();
-    private static final EventList<ReloadEvent> ONRELOAD = new EventList<ReloadEvent>();
-    private static final EventList<ReloadEvent> ONPOSTRELOAD = new EventList<ReloadEvent>();
+    private static final EventList<ReloadEvent> ONRELOAD = new EventList<>();
+    private static final EventList<ReloadEvent> ONPOSTRELOAD = new EventList<>();
 
     static {
         minetweakerCommands = new HashMap<String, MineTweakerCommand>();
@@ -621,28 +621,7 @@ public class MineTweakerImplementationAPI {
             events.onPlayerLoggedIn(LISTEN_LOGIN);
             events.onPlayerLoggedOut(LISTEN_LOGOUT);
         }
-//
-//		byte[] currentScript = MineTweakerAPI.tweaker.getScriptData();
-//		if (currentScript != null) {
-//			System.out.println("Already loaded a script before");
-//
-//			// alread loaded a script
-//			byte[] stagedScript = MineTweakerAPI.tweaker.getStagedScriptData();
-//
-//			if (Arrays.equals(currentScript, stagedScript)) {
-//				System.out.println("No reload needed");
-//				return; // no reload necessary
-//			}
-//
-//			if (MineTweakerAPI.game.isLocked()) {
-//				System.out.println("Reload blocked");
-//				MineTweakerAPI.game.signalLockError();
-//				return;
-//			}
-//		} else {	
-//			System.out.println("First time loading a script, go ahead");
-//		}
-
+        
         MineTweakerAPI.tweaker.rollback();
         if (MineTweakerAPI.server != null) {
             if (!MineTweakerAPI.server.isCommandAdded("minetweaker")) {

--- a/MineTweaker3-API/src/main/java/minetweaker/api/recipes/IRecipeManager.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/api/recipes/IRecipeManager.java
@@ -40,7 +40,7 @@ public interface IRecipeManager {
      * @return number of removed recipes
      */
     @ZenMethod
-    int remove(IIngredient output, @Optional boolean nbtMatch);
+    void remove(IIngredient output, @Optional boolean nbtMatch);
     
     /**
      * Adds a shaped recipe.
@@ -81,7 +81,7 @@ public interface IRecipeManager {
      * @return number of removed recipes
      */
     @ZenMethod
-    int removeShaped(IIngredient output, @Optional IIngredient[][] ingredients);
+    void removeShaped(IIngredient output, @Optional IIngredient[][] ingredients);
     
     /**
      * Removes shapeless recipes.
@@ -94,7 +94,7 @@ public interface IRecipeManager {
      * @return number of removed recipes
      */
     @ZenMethod
-    int removeShapeless(IIngredient output, @Optional IIngredient[] ingredients, @Optional boolean wildcard);
+    void removeShapeless(IIngredient output, @Optional IIngredient[] ingredients, @Optional boolean wildcard);
     
     /**
      * Performs a crafting with the specified ingredients. Returns null if no

--- a/MineTweaker3-API/src/main/java/minetweaker/api/recipes/ShapedRecipe.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/api/recipes/ShapedRecipe.java
@@ -28,21 +28,14 @@ public class ShapedRecipe implements ICraftingRecipe {
     
     public ShapedRecipe(IItemStack output, IIngredient[][] ingredients, IRecipeFunction function, IRecipeAction action, boolean mirrored) {
         int numIngredients = 0;
-        for(int i = 0; i < ingredients.length; i++) {
-            IIngredient[] ingredient = ingredients[i];
-            for(int i1 = 0; i1 < ingredient.length; i1++) {
-                if(ingredient[i1] != null) {
+        for (IIngredient[] ingredient : ingredients) {
+            for (IIngredient iIngredient : ingredient) {
+                if (iIngredient != null) {
                     numIngredients++;
                 }
             }
         }
-        //        for(IIngredient[] row : ingredients) {
-        //			for(IIngredient ingredient : row) {
-        //				if(ingredient != null) {
-        //					numIngredients++;
-        //				}
-        //			}
-        //		}
+
         this.posx = new byte[numIngredients];
         this.posy = new byte[numIngredients];
         this.output = output;

--- a/MineTweaker3-API/src/main/java/minetweaker/runtime/MTTweaker.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/runtime/MTTweaker.java
@@ -111,7 +111,7 @@ public class MTTweaker implements ITweaker {
 		System.out.println("Loading scripts");
 
 		scriptData = ScriptProviderMemory.collect(scriptProvider);
-		Set<String> executed = new HashSet<String>();
+		Set<String> executed = new HashSet<>();
 
 		Iterator<IScriptIterator> scripts = scriptProvider.getScripts();
 		while (scripts.hasNext()) {
@@ -120,10 +120,10 @@ public class MTTweaker implements ITweaker {
 			if (!executed.contains(script.getGroupName())) {
 				executed.add(script.getGroupName());
 
-				Map<String, byte[]> classes = new HashMap<String, byte[]>();
+				Map<String, byte[]> classes = new HashMap<>();
 				IEnvironmentGlobal environmentGlobal = GlobalRegistry.makeGlobalEnvironment(classes);
 
-				List<ZenParsedFile> files = new ArrayList<ZenParsedFile>();
+				List<ZenParsedFile> files = new ArrayList<>();
 
 				while (script.next()) {
 					Reader reader = null;

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/FMLEventHandler.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/FMLEventHandler.java
@@ -10,6 +10,7 @@ import minetweaker.api.minecraft.MineTweakerMC;
 import minetweaker.api.player.IPlayer;
 import minetweaker.mc1710.network.MineTweakerLoadScriptsPacket;
 import minetweaker.mc1710.recipes.MCCraftingInventory;
+import minetweaker.mc1710.recipes.MCRecipeManager;
 import net.minecraft.entity.player.EntityPlayerMP;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
@@ -32,8 +33,8 @@ public class FMLEventHandler {
 	@SubscribeEvent
 	public void onPlayerItemCrafted(PlayerEvent.ItemCraftedEvent ev) {
 		IPlayer iPlayer = MineTweakerMC.getIPlayer(ev.player);
-		if (MineTweakerMod.INSTANCE.recipes.hasTransformerRecipes()) {
-			MineTweakerMod.INSTANCE.recipes.applyTransformations(MCCraftingInventory.get(ev.craftMatrix, ev.player), iPlayer);
+		if (MCRecipeManager.hasTransformerRecipes()) {
+			MCRecipeManager.applyTransformations(MCCraftingInventory.get(ev.craftMatrix, ev.player), iPlayer);
 		}
 
 		if (MineTweakerImplementationAPI.events.hasPlayerCrafted()) {

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/MineTweakerMod.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/MineTweakerMod.java
@@ -35,10 +35,13 @@ import minetweaker.runtime.*;
 import minetweaker.runtime.providers.ScriptProviderCascade;
 import minetweaker.runtime.providers.ScriptProviderCustom;
 import minetweaker.runtime.providers.ScriptProviderDirectory;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.MinecraftForge;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Main mod class. Performs some general logic, initialization of the API and
@@ -77,19 +80,20 @@ public class MineTweakerMod {
 	@Mod.Instance(MODID)
 	public static MineTweakerMod INSTANCE;
 
-	public final MCRecipeManager recipes;
 	private final IScriptProvider scriptsGlobal;
 	private final ScriptProviderCustom scriptsIMC;
 
 	public MineTweakerMod() {
+		MCRecipeManager.recipes = (List<IRecipe>) CraftingManager.getInstance().getRecipeList();
 		MineTweakerImplementationAPI.init(
 				new MCOreDict(),
-				recipes = new MCRecipeManager(),
+				new MCRecipeManager(),
 				new MCFurnaceManager(),
 				MCGame.INSTANCE,
 				new MCLoadedMods(),
 				new MCFormatter(),
 				new MCVanilla());
+
 
 		MineTweakerImplementationAPI.logger.addLogger(new FileLogger(new File("minetweaker.log")));
 		MineTweakerImplementationAPI.platform = MCPlatformFunctions.INSTANCE;

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/item/MCItemStack.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/item/MCItemStack.java
@@ -53,7 +53,7 @@ public class MCItemStack implements IItemStack {
 			throw new IllegalArgumentException("stack cannot be null");
 
 		stack = itemStack.copy();
-		items = Collections.<IItemStack>singletonList(this);
+		items = Collections.singletonList(this);
 	}
 
 	public MCItemStack(ItemStack itemStack, boolean wildcardSize) {
@@ -67,13 +67,13 @@ public class MCItemStack implements IItemStack {
 			throw new IllegalArgumentException("stack cannot be null");
 
 		stack = itemStack;
-		items = Collections.<IItemStack>singletonList(this);
+		items = Collections.singletonList(this);
 		this.tag = tag;
 	}
 
 	private MCItemStack(ItemStack itemStack, IData tag, boolean wildcardSize) {
 		stack = itemStack;
-		items = Collections.<IItemStack>singletonList(this);
+		items = Collections.singletonList(this);
 		this.tag = tag;
 		this.wildcardSize = wildcardSize;
 	}

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/recipes/MCRecipeManager.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/recipes/MCRecipeManager.java
@@ -2,12 +2,21 @@ package minetweaker.mc1710.recipes;
 
 import minetweaker.IUndoableAction;
 import minetweaker.MineTweakerAPI;
+import minetweaker.MineTweakerImplementationAPI;
 import minetweaker.api.item.IIngredient;
 import minetweaker.api.item.IItemStack;
 import minetweaker.api.minecraft.MineTweakerMC;
 import minetweaker.api.player.IPlayer;
-import minetweaker.api.recipes.*;
+import minetweaker.api.recipes.ICraftingInventory;
+import minetweaker.api.recipes.ICraftingRecipe;
+import minetweaker.api.recipes.IRecipeAction;
+import minetweaker.api.recipes.IRecipeFunction;
+import minetweaker.api.recipes.IRecipeManager;
+import minetweaker.api.recipes.ShapedRecipe;
+import minetweaker.api.recipes.ShapelessRecipe;
+import minetweaker.mc1710.item.MCItemStack;
 import minetweaker.mc1710.util.MineTweakerHacks;
+import minetweaker.util.IEventHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.InventoryCrafting;
@@ -18,30 +27,40 @@ import net.minecraft.item.crafting.ShapedRecipes;
 import net.minecraft.item.crafting.ShapelessRecipes;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
+import org.apache.commons.lang3.tuple.Pair;
 import stanhebben.zenscript.annotations.Optional;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
-import static minetweaker.api.minecraft.MineTweakerMC.*;
+import static minetweaker.api.minecraft.MineTweakerMC.getIItemStack;
+import static minetweaker.api.minecraft.MineTweakerMC.getItemStack;
+import static minetweaker.api.minecraft.MineTweakerMC.getOreDict;
 
 /**
  * @author Stan
  */
-public class MCRecipeManager implements IRecipeManager {
-    private final List<IRecipe> recipes;
-    private final List<ICraftingRecipe> transformerRecipes;
+public final class MCRecipeManager implements IRecipeManager {
+    public static final List<ActionBaseAddRecipe> recipesToAdd = new ArrayList<>();
+    public static final List<ActionBaseRemoveRecipes> recipesToRemove = new ArrayList<>();
+    public static final ActionRemoveRecipesNoIngredients actionRemoveRecipesNoIngredients = new ActionRemoveRecipesNoIngredients();
+
+    public static List<IRecipe> recipes;
+    public static final List<ICraftingRecipe> transformerRecipes = new ArrayList<>();
 
     public MCRecipeManager() {
-        recipes = (List<IRecipe>) CraftingManager.getInstance().getRecipeList();
-        transformerRecipes = new ArrayList<ICraftingRecipe>();
+        MineTweakerImplementationAPI.onPostReload(new HandlePostReload());
     }
 
-    public boolean hasTransformerRecipes() {
+    public static boolean hasTransformerRecipes() {
         return transformerRecipes.size() > 0;
     }
 
-    public void applyTransformations(ICraftingInventory inventory, IPlayer byPlayer) {
+    public static void applyTransformations(ICraftingInventory inventory, IPlayer byPlayer) {
         for (ICraftingRecipe recipe : transformerRecipes) {
             if (recipe.matches(inventory)) {
                 recipe.applyTransformers(inventory, byPlayer);
@@ -50,9 +69,35 @@ public class MCRecipeManager implements IRecipeManager {
         }
     }
 
+    private static boolean matches(Object input, IIngredient ingredient) {
+        if ((input == null) != (ingredient == null)) {
+            return false;
+        } else if (ingredient != null) {
+            if (input instanceof ItemStack) {
+                return ingredient.matches(getIItemStack((ItemStack) input));
+            } else if (input instanceof String) {
+                return ingredient.contains(getOreDict((String) input));
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public List<ICraftingRecipe> getAll() {
+        List<ICraftingRecipe> results = new ArrayList<>();
+
+        for (IRecipe recipe : recipes) {
+            ICraftingRecipe converted = RecipeConverter.toCraftingRecipe(recipe);
+            results.add(converted);
+        }
+
+        return results;
+    }
+
     @Override
     public List<ICraftingRecipe> getRecipesFor(IIngredient ingredient) {
-        List<ICraftingRecipe> results = new ArrayList<ICraftingRecipe>();
+        List<ICraftingRecipe> results = new ArrayList<>();
 
         for (IRecipe recipe : recipes) {
             if (ingredient.matches(MineTweakerMC.getIItemStack(recipe.getRecipeOutput()))) {
@@ -65,203 +110,56 @@ public class MCRecipeManager implements IRecipeManager {
     }
 
     @Override
-    public List<ICraftingRecipe> getAll() {
-        List<ICraftingRecipe> results = new ArrayList<ICraftingRecipe>();
-
-        for (IRecipe recipe : recipes) {
-            ICraftingRecipe converted = RecipeConverter.toCraftingRecipe(recipe);
-            results.add(converted);
+    public void remove(IIngredient output, @Optional boolean nbtMatch) {
+        if(output == null) {
+            MineTweakerAPI.logError("Cannot remove recipes for a null item!");
+            return;
         }
-
-        return results;
-    }
-
-    @Override
-    public int remove(IIngredient output, @Optional boolean nbtMatch) {
-        List<IRecipe> toRemove = new ArrayList<IRecipe>();
-        List<Integer> removeIndex = new ArrayList<Integer>();
-        for (int i = 0; i < recipes.size(); i++) {
-            IRecipe recipe = recipes.get(i);
-
-            // certain special recipes have no predefined output. ignore those
-            // since these cannot be removed with MineTweaker scripts
-            if (recipe.getRecipeOutput() != null) {
-                if (nbtMatch ? output.matchesExact(getIItemStack(recipe.getRecipeOutput())) : output.matches(getIItemStack(recipe.getRecipeOutput()))) {
-                    toRemove.add(recipe);
-                    removeIndex.add(i);
-                }
-            }
-        }
-
-        MineTweakerAPI.apply(new ActionRemoveRecipes(toRemove, removeIndex));
-        return toRemove.size();
+        actionRemoveRecipesNoIngredients.addOutput(output, nbtMatch);
     }
 
     @Override
     public void addShaped(IItemStack output, IIngredient[][] ingredients, IRecipeFunction function, IRecipeAction action) {
-        addShaped(output, ingredients, function, action, false);
+        recipesToAdd.add(new ActionAddShapedRecipe(output, ingredients, function, action, false));
     }
 
     @Override
     public void addShapedMirrored(IItemStack output, IIngredient[][] ingredients, IRecipeFunction function, IRecipeAction action) {
-        addShaped(output, ingredients, function, action, true);
+        recipesToAdd.add(new ActionAddShapedRecipe(output, ingredients, function, action, true));
     }
 
     @Override
     public void addShapeless(IItemStack output, IIngredient[] ingredients, IRecipeFunction function, IRecipeAction action) {
-        ShapelessRecipe recipe = new ShapelessRecipe(output, ingredients, function, action);
-        IRecipe irecipe = RecipeConverter.convert(recipe);
-        MineTweakerAPI.apply(new ActionAddRecipe(irecipe, recipe));
+        if(checkShapelessNulls(output, ingredients))
+            return;
+        
+        recipesToAdd.add(new ActionAddShapelessRecipe(output, ingredients, function, action));
+    }
+
+    private boolean checkShapelessNulls(IItemStack output, IIngredient[] ingredients) {
+        if(output != null && Arrays.stream(ingredients).allMatch(Objects::isNull)) {
+            MineTweakerAPI.logError("Null not allowed in shapeless recipes! Recipe for: " + output + " not created!");
+            return true;
+        }
+        return false;
     }
 
     @Override
-    public int removeShaped(IIngredient output, IIngredient[][] ingredients) {
-        int ingredientsWidth = 0;
-        int ingredientsHeight = 0;
-
-        if (ingredients != null) {
-            ingredientsHeight = ingredients.length;
-
-            for (int i = 0; i < ingredients.length; i++) {
-                ingredientsWidth = Math.max(ingredientsWidth, ingredients[i].length);
-            }
+    public void removeShaped(IIngredient output, IIngredient[][] ingredients) {
+        if(output == null) {
+            MineTweakerAPI.logError("Cannot remove recipes for a null item!");
+            return;
         }
-
-        List<IRecipe> toRemove = new ArrayList<IRecipe>();
-        List<Integer> removeIndex = new ArrayList<Integer>();
-        outer:
-        for (int i = 0; i < recipes.size(); i++) {
-            IRecipe recipe = recipes.get(i);
-
-            if (recipe.getRecipeOutput() == null || !output.matches(getIItemStack(recipe.getRecipeOutput()))) {
-                continue;
-            }
-
-            if (ingredients != null) {
-                if (recipe instanceof ShapedRecipes) {
-                    ShapedRecipes srecipe = (ShapedRecipes) recipe;
-                    if (ingredientsWidth != srecipe.recipeWidth || ingredientsHeight != srecipe.recipeHeight) {
-                        continue;
-                    }
-
-                    for (int j = 0; j < ingredientsHeight; j++) {
-                        IIngredient[] row = ingredients[j];
-                        for (int k = 0; k < ingredientsWidth; k++) {
-                            IIngredient ingredient = k > row.length ? null : row[k];
-                            ItemStack recipeIngredient = srecipe.recipeItems[j * srecipe.recipeWidth + k];
-
-                            if (!matches(recipeIngredient, ingredient)) {
-                                continue outer;
-                            }
-                        }
-                    }
-                } else if (recipe instanceof ShapedOreRecipe) {
-                    ShapedOreRecipe srecipe = (ShapedOreRecipe) recipe;
-                    int recipeWidth = MineTweakerHacks.getShapedOreRecipeWidth(srecipe);
-                    int recipeHeight = srecipe.getRecipeSize() / recipeWidth;
-                    if (ingredientsWidth != recipeWidth || ingredientsHeight != recipeHeight) {
-                        continue;
-                    }
-
-                    for (int j = 0; j < ingredientsHeight; j++) {
-                        IIngredient[] row = ingredients[j];
-                        for (int k = 0; k < ingredientsWidth; k++) {
-                            IIngredient ingredient = k > row.length ? null : row[k];
-                            Object input = srecipe.getInput()[j * recipeWidth + k];
-                            if (!matches(input, ingredient)) {
-                                continue outer;
-                            }
-                        }
-                    }
-                }
-            } else {
-                if (recipe instanceof ShapedRecipes) {
-
-                } else if (recipe instanceof ShapedOreRecipe) {
-
-                } else {
-                    continue;
-                }
-            }
-
-            toRemove.add(recipe);
-            removeIndex.add(i);
-        }
-
-        MineTweakerAPI.apply(new ActionRemoveRecipes(toRemove, removeIndex));
-        return toRemove.size();
+        recipesToRemove.add(new ActionRemoveShapedRecipes(output, ingredients));
     }
 
     @Override
-    public int removeShapeless(IIngredient output, IIngredient[] ingredients, boolean wildcard) {
-        List<IRecipe> toRemove = new ArrayList<IRecipe>();
-        List<Integer> removeIndex = new ArrayList<Integer>();
-        outer:
-        for (int i = 0; i < recipes.size(); i++) {
-            IRecipe recipe = recipes.get(i);
-
-            if (recipe.getRecipeOutput() == null || !output.matches(getIItemStack(recipe.getRecipeOutput()))) {
-                continue;
-            }
-
-            if (ingredients != null) {
-                if (recipe instanceof ShapelessRecipes) {
-                    ShapelessRecipes srecipe = (ShapelessRecipes) recipe;
-
-                    if (ingredients.length > srecipe.getRecipeSize()) {
-                        continue;
-                    } else if (!wildcard && ingredients.length < srecipe.getRecipeSize()) {
-                        continue;
-                    }
-
-                    checkIngredient:
-                    for (int j = 0; j < ingredients.length; j++) {
-                        for (int k = 0; k < srecipe.getRecipeSize(); k++) {
-                            if (matches(srecipe.recipeItems.get(k), ingredients[j])) {
-                                continue checkIngredient;
-                            }
-                        }
-
-                        continue outer;
-                    }
-                } else if (recipe instanceof ShapelessOreRecipe) {
-                    ShapelessOreRecipe srecipe = (ShapelessOreRecipe) recipe;
-                    ArrayList<Object> inputs = srecipe.getInput();
-
-                    if (inputs.size() < ingredients.length) {
-                        continue;
-                    }
-                    if (!wildcard && inputs.size() > ingredients.length) {
-                        continue;
-                    }
-
-                    checkIngredient:
-                    for (int j = 0; j < ingredients.length; j++) {
-                        for (int k = 0; k < srecipe.getRecipeSize(); k++) {
-                            if (matches(inputs.get(k), ingredients[j])) {
-                                continue checkIngredient;
-                            }
-                        }
-
-                        continue outer;
-                    }
-                }
-            } else {
-                if (recipe instanceof ShapelessRecipes) {
-
-                } else if (recipe instanceof ShapelessOreRecipe) {
-
-                } else {
-                    continue;
-                }
-            }
-
-            toRemove.add(recipe);
-            removeIndex.add(i);
+    public void removeShapeless(IIngredient output, IIngredient[] ingredients, boolean wildcard) {
+        if(output == null) {
+            MineTweakerAPI.logError("Cannot remove recipes for a null item!");
+            return;
         }
-
-        MineTweakerAPI.apply(new ActionRemoveRecipes(toRemove, removeIndex));
-        return toRemove.size();
+        recipesToRemove.add(new ActionRemoveShapelessRecipes(output, ingredients, wildcard));
     }
 
     @Override
@@ -294,6 +192,352 @@ public class MCRecipeManager implements IRecipeManager {
             return getIItemStack(result);
         }
     }
+    
+    public abstract static class ActionBaseRemoveRecipes implements IUndoableAction {
+        public void removeRecipes(Set<IRecipe> toRemove ) {
+            recipes.removeIf(toRemove::contains);
+        }
+    }
+
+    public static class ActionRemoveRecipesNoIngredients extends ActionBaseRemoveRecipes implements IUndoableAction {
+        // pair of output, nbtMatch
+        private final List<Pair<IIngredient, Boolean>> outputs = new ArrayList<>();
+
+        public void addOutput(IIngredient output, @Optional boolean nbtMatch) {
+            outputs.add(Pair.of(output, nbtMatch));
+        }
+
+        @Override
+        public void apply() {
+            Set<IRecipe> toRemove = new HashSet<>();
+
+            for (final IRecipe recipe : recipes) {
+                final ItemStack recipeOutput = recipe.getRecipeOutput();
+                if (recipeOutput != null) {
+                    final IItemStack stack = getIItemStack(recipeOutput);
+                    if (matches(stack)) {
+                        toRemove.add(recipe);
+                    }
+                }
+            }
+            super.removeRecipes(toRemove);
+        }
+
+        @Override
+        public boolean canUndo() {
+            return false;
+        }
+
+        @Override
+        public void undo() {
+
+        }
+
+        @Override
+        public String describe() {
+            return "Removing recipes for various outputs";
+        }
+
+        @Override
+        public String describeUndo() {
+            return null;
+        }
+
+        @Override
+        public Object getOverrideKey() {
+            return null;
+        }
+
+        private boolean matches(IItemStack stack) {
+            for(Pair<IIngredient, Boolean> entry : outputs) {
+                IIngredient output = entry.getKey();
+                Boolean nbtMatch = entry.getValue();
+                if(nbtMatch ? output.matchesExact(stack) : output.matches(stack)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    }
+    
+    public static class ActionRemoveShapelessRecipes extends ActionBaseRemoveRecipes implements IUndoableAction {
+        final IIngredient output;
+        final IIngredient[] ingredients;
+        final boolean wildcard;
+
+        public ActionRemoveShapelessRecipes(IIngredient output, IIngredient[] ingredients, boolean wildcard) {
+            this.output = output;
+            this.ingredients = ingredients;
+            this.wildcard = wildcard;
+        }
+        
+        @Override
+        public void apply() {
+            Set<IRecipe> toRemove = new HashSet<>();
+
+            outer:
+            for (IRecipe recipe : recipes) {
+                if (recipe.getRecipeOutput() == null || !output.matches(new MCItemStack(recipe.getRecipeOutput()))) {
+                    continue;
+                }
+                if (recipe instanceof ShapedRecipes) {
+                    continue;
+                }
+                if (!(recipe instanceof ShapelessRecipes) && !(recipe instanceof ShapelessOreRecipe)) {
+                    continue;
+                }
+                if (ingredients != null) {
+                    if (recipe instanceof ShapelessRecipes) {
+                        ShapelessRecipes srecipe = (ShapelessRecipes) recipe;
+
+                        if (ingredients.length > srecipe.getRecipeSize()) {
+                            continue;
+                        } else if (!wildcard && ingredients.length < srecipe.getRecipeSize()) {
+                            continue;
+                        }
+
+                        checkIngredient:
+                        for (IIngredient ingredient : ingredients) {
+                            for (int k = 0; k < srecipe.getRecipeSize(); k++) {
+                                if (matches(srecipe.recipeItems.get(k), ingredient)) {
+                                    continue checkIngredient;
+                                }
+                            }
+
+                            continue outer;
+                        }
+                    } else if (recipe instanceof ShapelessOreRecipe) {
+                        ShapelessOreRecipe srecipe = (ShapelessOreRecipe) recipe;
+                        ArrayList<Object> inputs = srecipe.getInput();
+
+                        if (inputs.size() < ingredients.length) {
+                            continue;
+                        }
+                        if (!wildcard && inputs.size() > ingredients.length) {
+                            continue;
+                        }
+
+                        checkIngredient:
+                        for (IIngredient ingredient : ingredients) {
+                            for (int k = 0; k < srecipe.getRecipeSize(); k++) {
+                                if (matches(inputs.get(k), ingredient)) {
+                                    continue checkIngredient;
+                                }
+                            }
+
+                            continue outer;
+                        }
+                    }
+                }
+
+                toRemove.add(recipe);
+            }
+            MineTweakerAPI.logInfo("Removing " + toRemove.size() + " Shapeless recipes.");
+            super.removeRecipes(toRemove);            
+        }
+
+        @Override
+        public boolean canUndo() {
+            return false;
+        }
+
+        @Override
+        public void undo() {
+
+        }
+
+        @Override
+        public String describe() {
+            if(output != null) {
+                return "Removing Shapeless recipes for " + output.toString();
+            } else {
+                return "Trying to remove recipes for invalid output";
+            }
+        }
+
+        @Override
+        public String describeUndo() {
+            return null;
+        }
+
+        @Override
+        public Object getOverrideKey() {
+            return null;
+        }
+    }
+    
+    public static class ActionRemoveShapedRecipes extends ActionBaseRemoveRecipes implements IUndoableAction {
+        final IIngredient output;
+        final IIngredient[][] ingredients;
+
+
+        public ActionRemoveShapedRecipes(IIngredient output, IIngredient[][] ingredients) {
+            this.output = output;
+            this.ingredients = ingredients;
+        }
+
+        @Override
+        public void apply() {
+            int ingredientsWidth = 0;
+            int ingredientsHeight = 0;
+
+            if (ingredients != null) {
+                ingredientsHeight = ingredients.length;
+
+                for (IIngredient[] ingredient : ingredients) {
+                    ingredientsWidth = Math.max(ingredientsWidth, ingredient.length);
+                }
+            }
+
+            final Set<IRecipe> toRemove = new HashSet<>();
+
+            outer:
+            for (final IRecipe recipe : recipes) {
+                final ItemStack output = recipe.getRecipeOutput();
+                if (output == null || !this.output.matches(new MCItemStack(output))) {
+                    continue;
+                }
+                if (!(recipe instanceof ShapedRecipes || recipe instanceof ShapedOreRecipe))
+                    continue;
+                
+                if (ingredients != null) {
+                    boolean ore = recipe instanceof ShapedOreRecipe;
+                    final ShapedRecipes shapedRecipe = !ore ? (ShapedRecipes) recipe : null;
+                    final ShapedOreRecipe shapedOreRecipe = ore ? (ShapedOreRecipe) recipe : null;
+
+                    final int recipeWidth = ore ? MineTweakerHacks.getShapedOreRecipeWidth(shapedOreRecipe) : shapedRecipe.recipeWidth;
+                    final int recipeHeight = ore ? shapedOreRecipe.getRecipeSize() / recipeWidth : shapedRecipe.recipeHeight;
+                    
+                    if (ingredientsWidth != recipeWidth || ingredientsHeight != recipeHeight) {
+                        continue;
+                    }
+
+                    for (int j = 0; j < ingredientsHeight; j++) {
+                        final IIngredient[] row = ingredients[j];
+                        for (int k = 0; k < ingredientsWidth; k++) {
+                            final IIngredient ingredient = k > row.length ? null : row[k];
+                            final Object input = (ore ? shapedOreRecipe.getInput() : shapedRecipe.recipeItems)[j * recipeWidth + k];
+                            
+                            if (!matches(input, ingredient)) {
+                                continue outer;
+                            }
+                        }
+                    }
+                }
+                // If null ingredient list given, remove all ShapedRecipes with the given output
+                toRemove.add(recipe);
+            }
+
+            MineTweakerAPI.logInfo(toRemove.size() + " removed");
+            super.removeRecipes(toRemove);            
+        }
+
+        @Override
+        public boolean canUndo() {
+            return false;
+        }
+
+        @Override
+        public void undo() {
+
+        }
+
+        @Override
+        public String describe() {
+            return null;
+        }
+
+        @Override
+        public String describeUndo() {
+            return null;
+        }
+
+        @Override
+        public Object getOverrideKey() {
+            return null;
+        }
+    }
+    
+    public static class ActionBaseAddRecipe implements IUndoableAction {
+        private final IRecipe iRecipe;
+        private final ICraftingRecipe craftingRecipe;
+        
+        protected final IItemStack output;
+        protected final boolean isShaped;
+
+        private ActionBaseAddRecipe(ICraftingRecipe craftingRecipe, IItemStack output, boolean isShaped) {
+            this.iRecipe = RecipeConverter.convert(craftingRecipe);
+            this.craftingRecipe = craftingRecipe;
+            
+            this.output = output;
+            this.isShaped = isShaped;
+            
+//            if(craftingRecipe.hasTransformers())
+//                transformerRecipes.add(craftingRecipe);
+        }
+
+        @Override
+        public void apply() {
+            recipes.add(iRecipe);
+            if (craftingRecipe.hasTransformers())
+                transformerRecipes.add(craftingRecipe);
+        }
+
+        @Override
+        public boolean canUndo() {
+            return false;
+        }
+
+        @Override
+        public void undo() {
+
+        }
+
+        @Override
+        public String describe() {
+            if(output != null) {
+                return "Adding " + (isShaped ? "shaped" : "shapeless") + " recipe for " + output.getDisplayName();
+            } else {
+                return "Trying to add " + (isShaped ? "shaped" : "shapeless") + "recipe without correct output";
+            }
+        }
+
+        @Override
+        public String describeUndo() {
+            return null;
+        }
+
+        @Override
+        public Object getOverrideKey() {
+            return null;
+        }
+    }
+
+    private static class ActionAddShapedRecipe extends ActionBaseAddRecipe {
+        public ActionAddShapedRecipe(IItemStack output, IIngredient[][] ingredients, IRecipeFunction function, IRecipeAction action, boolean mirrored) {
+            super(new ShapedRecipe(output, ingredients, function, action, mirrored), output, true);
+        }
+    }
+    
+    private static class ActionAddShapelessRecipe extends ActionBaseAddRecipe {
+        public ActionAddShapelessRecipe(IItemStack output, IIngredient[] ingredients, IRecipeFunction function, IRecipeAction action) {
+            super(new ShapelessRecipe(output, ingredients, function, action), output, false);
+        }
+    }
+
+    public static class HandlePostReload implements IEventHandler<MineTweakerImplementationAPI.ReloadEvent>
+    {
+        @Override
+        public void handle(MineTweakerImplementationAPI.ReloadEvent event)
+        {
+            System.out.println("MineTweaker: Applying additions and removals");
+            MineTweakerAPI.apply(MCRecipeManager.actionRemoveRecipesNoIngredients);
+            MCRecipeManager.recipesToRemove.forEach(MineTweakerAPI::apply);
+            MCRecipeManager.recipesToAdd.forEach(MineTweakerAPI::apply);
+            
+        }
+    }
 
     private class ContainerVirtual extends Container {
         @Override
@@ -301,119 +545,5 @@ public class MCRecipeManager implements IRecipeManager {
             return false;
         }
     }
-
-    private class ActionRemoveRecipes implements IUndoableAction {
-        private final List<Integer> removingIndices;
-        private final List<IRecipe> removingRecipes;
-
-        public ActionRemoveRecipes(List<IRecipe> recipes, List<Integer> indices) {
-            this.removingIndices = indices;
-            this.removingRecipes = recipes;
-        }
-
-        @Override
-        public void apply() {
-            for (int i = removingIndices.size() - 1; i >= 0; i--) {
-                recipes.remove((int) removingIndices.get(i));
-            }
-        }
-
-        @Override
-        public boolean canUndo() {
-            return true;
-        }
-
-        @Override
-        public void undo() {
-            for (int i = 0; i < removingIndices.size(); i++) {
-                int index = Math.min(recipes.size(), removingIndices.get(i));
-                recipes.add(index, removingRecipes.get(i));
-            }
-        }
-
-        @Override
-        public String describe() {
-            return "Removing " + removingIndices.size() + " recipes";
-        }
-
-        @Override
-        public String describeUndo() {
-            return "Restoring " + removingIndices.size() + " recipes";
-        }
-
-        @Override
-        public Object getOverrideKey() {
-            return null;
-        }
-    }
-
-    private class ActionAddRecipe implements IUndoableAction {
-        private final IRecipe recipe;
-        private final ICraftingRecipe craftingRecipe;
-
-        public ActionAddRecipe(IRecipe recipe, ICraftingRecipe craftingRecipe) {
-            this.recipe = recipe;
-            this.craftingRecipe = craftingRecipe;
-        }
-
-        @Override
-        public void apply() {
-            recipes.add(recipe);
-            if (craftingRecipe.hasTransformers()) {
-                transformerRecipes.add(craftingRecipe);
-            }
-        }
-
-        @Override
-        public boolean canUndo() {
-            return true;
-        }
-
-        @Override
-        public void undo() {
-            recipes.remove(recipe);
-            if (craftingRecipe.hasTransformers()) {
-                transformerRecipes.remove(craftingRecipe);
-            }
-        }
-
-        @Override
-        public String describe() {
-            return "Adding recipe for " + recipe.getRecipeOutput().getDisplayName();
-        }
-
-        @Override
-        public String describeUndo() {
-            return "Removing recipe for " + recipe.getRecipeOutput().getDisplayName();
-        }
-
-        @Override
-        public Object getOverrideKey() {
-            return null;
-        }
-    }
-
-    private void addShaped(IItemStack output, IIngredient[][] ingredients, IRecipeFunction function, IRecipeAction action, boolean mirrored) {
-        ShapedRecipe recipe = new ShapedRecipe(output, ingredients, function, action, mirrored);
-        IRecipe irecipe = RecipeConverter.convert(recipe);
-        MineTweakerAPI.apply(new ActionAddRecipe(irecipe, recipe));
-    }
-
-    private static boolean matches(Object input, IIngredient ingredient) {
-        if ((input == null) != (ingredient == null)) {
-            return false;
-        } else if (ingredient != null) {
-            if (input instanceof ItemStack) {
-                if (!ingredient.matches(getIItemStack((ItemStack) input))) {
-                    return false;
-                }
-            } else if (input instanceof String) {
-                if (!ingredient.contains(getOreDict((String) input))) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
+    
 }

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/recipes/RecipeConverter.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/recipes/RecipeConverter.java
@@ -53,7 +53,13 @@ public class RecipeConverter {
 		}
 		return type;
 	}
-
+	public static IRecipe convert(ICraftingRecipe recipe) {
+		if (recipe instanceof ShapedRecipe)
+			return RecipeConverter.convert((ShapedRecipe)recipe);
+		else
+			return RecipeConverter.convert((ShapelessRecipe) recipe);
+	}
+	
 	public static IRecipe convert(ShapelessRecipe recipe) {
 		IIngredient[] ingredients = recipe.getIngredients();
 		int type = getRecipeType(ingredients);


### PR DESCRIPTION
* Batch up remove() and rewrite the list using .removeIf instead of shifting it for each remove.
* Change where the copy of ItemStack is done, down from ~25k * 5k (~100mil) + allocations, to some much smaller multiple of 25k + 4k.


Takes the script loading times from ~60+ seconds to ~15 seconds.