### PR TITLE
Sort received scripts in alphabetic order to prevent weird recipe loss

### DIFF
--- a/MineTweaker3-API/src/main/java/minetweaker/runtime/providers/ScriptProviderMemory.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/runtime/providers/ScriptProviderMemory.java
@@ -12,13 +12,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 import minetweaker.MineTweakerAPI;
@@ -74,7 +68,7 @@ public class ScriptProviderMemory implements IScriptProvider {
 	private final Map<String, MemoryModule> modules;
 
 	public ScriptProviderMemory(byte[] scripts) {
-		modules = new HashMap<String, MemoryModule>();
+		modules = new TreeMap<String, MemoryModule>();
 
 		try {
 			InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(scripts));


### PR DESCRIPTION
HashMap does not provide ordering guarantee of any kind. Out of order execution is usually fine, but caused huge mess (random item hidden from NEI, random recipe not showing up in NEI etc etc) when I  was tweaking those LP recipes on a dedicated server. This change ensures scripts are always executed in alphabetic order. This is consistent as it would be on the server side (see ScriptProviderDirectory's explicit sorting)