### PR TITLE
Fix runtime warning

### DIFF
--- a/src/main/java/minetweaker/api/vanilla/ILootFunction.java
+++ b/src/main/java/minetweaker/api/vanilla/ILootFunction.java
@@ -12,7 +12,5 @@ public interface ILootFunction {
     String getName();
 
     @ZenSetter
-    void setName();
-
-
+    void setName(String name);
 }


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8263 by giving this setter an argument.

This warning doesn't really affect anything. ILootFunction is not used by anything at all. It's probably for a different minecraft revision.