### PR TITLE
Add a chat message length limit to avoid crashing with too big packets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1646409286
+//version: 1650343995
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -568,7 +568,7 @@ publishing {
                 artifact source: shadowJar, classifier: ""
             }
             if(!noPublishedSources) {
-                artifact source: sourcesJar, classifier: "src"
+                artifact source: sourcesJar, classifier: "sources"
             }
             artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
             if (apiPackage) {

--- a/src/main/java/minetweaker/api/player/IPlayer.java
+++ b/src/main/java/minetweaker/api/player/IPlayer.java
@@ -35,6 +35,8 @@ public interface IPlayer {
     @ZenMethod
     void sendChat(IChatMessage message);
 
+    int MAX_CHAT_MESSAGE_LENGTH = 512;
+
     @ZenMethod
     void sendChat(String message);
 

--- a/src/main/java/minetweaker/mc1710/player/CommandBlockPlayer.java
+++ b/src/main/java/minetweaker/mc1710/player/CommandBlockPlayer.java
@@ -37,22 +37,22 @@ public class CommandBlockPlayer implements IPlayer{
     public IData getData(){
         return null;
     }
-    
+
     @Override
     public int getXP() {
         return 0;
     }
-    
+
     @Override
     public void setXP(int xp) {
-    
+
     }
-    
+
     @Override
     public void removeXP(int xp) {
-    
+
     }
-    
+
     @Override
     public void update(IData data){
 
@@ -70,6 +70,10 @@ public class CommandBlockPlayer implements IPlayer{
 
     @Override
     public void sendChat(String message){
+        if (message.length() > MAX_CHAT_MESSAGE_LENGTH)
+        {
+            message = message.substring(0, MAX_CHAT_MESSAGE_LENGTH);
+        }
         sender.addChatMessage(new ChatComponentText(message));
     }
 

--- a/src/main/java/minetweaker/mc1710/player/MCPlayer.java
+++ b/src/main/java/minetweaker/mc1710/player/MCPlayer.java
@@ -51,25 +51,25 @@ public class MCPlayer implements IPlayer {
 	public IData getData() {
 		return NBTConverter.from(player.getEntityData(), true);
 	}
-    
+
     @Override
     public int getXP() {
         return player.experienceLevel;
     }
-    
+
     @Override
     public void setXP(int xp) {
         player.experienceLevel = 0;
         player.addExperienceLevel(xp);
     }
-    
+
     @Override
     public void removeXP(int xp) {
         final int newLvl = Math.max(0, player.experienceLevel - xp);
         player.experienceLevel = 0;
         player.addExperienceLevel(newLvl);
     }
-    
+
     @Override
 	public void update(IData data) {
 		NBTConverter.updateMap(player.getEntityData(), data);
@@ -87,6 +87,10 @@ public class MCPlayer implements IPlayer {
 
 	@Override
 	public void sendChat(String message) {
+        if (message.length() > MAX_CHAT_MESSAGE_LENGTH)
+        {
+            message = message.substring(0, MAX_CHAT_MESSAGE_LENGTH);
+        }
 		player.addChatMessage(new ChatComponentText(message));
 	}
 

--- a/src/main/java/minetweaker/mc1710/player/RconPlayer.java
+++ b/src/main/java/minetweaker/mc1710/player/RconPlayer.java
@@ -38,22 +38,22 @@ public class RconPlayer implements IPlayer {
     public IData getData() {
         return null;
     }
-    
+
     @Override
     public int getXP() {
         return 0;
     }
-    
+
     @Override
     public void setXP(int xp) {
-    
+
     }
-    
+
     @Override
     public void removeXP(int xp) {
-    
+
     }
-    
+
     @Override
     public void update(IData data) {
 
@@ -71,6 +71,10 @@ public class RconPlayer implements IPlayer {
 
     @Override
     public void sendChat(String message) {
+        if (message.length() > MAX_CHAT_MESSAGE_LENGTH)
+        {
+            message = message.substring(0, MAX_CHAT_MESSAGE_LENGTH);
+        }
         sender.addChatMessage(new ChatComponentText(message));
     }
 

--- a/src/main/java/minetweaker/mc1710/player/RconPlayer.java
+++ b/src/main/java/minetweaker/mc1710/player/RconPlayer.java
@@ -71,10 +71,6 @@ public class RconPlayer implements IPlayer {
 
     @Override
     public void sendChat(String message) {
-        if (message.length() > MAX_CHAT_MESSAGE_LENGTH)
-        {
-            message = message.substring(0, MAX_CHAT_MESSAGE_LENGTH);
-        }
         sender.addChatMessage(new ChatComponentText(message));
     }
 

--- a/src/main/java/minetweaker/mc1710/server/ServerPlayer.java
+++ b/src/main/java/minetweaker/mc1710/server/ServerPlayer.java
@@ -76,10 +76,6 @@ public class ServerPlayer implements IPlayer {
 
 	@Override
 	public void sendChat(String message) {
-        if (message.length() > MAX_CHAT_MESSAGE_LENGTH)
-        {
-            message = message.substring(0, MAX_CHAT_MESSAGE_LENGTH);
-        }
 		DedicatedServer.getServer().addChatMessage(new ChatComponentText(message));
 	}
 

--- a/src/main/java/minetweaker/mc1710/server/ServerPlayer.java
+++ b/src/main/java/minetweaker/mc1710/server/ServerPlayer.java
@@ -48,22 +48,22 @@ public class ServerPlayer implements IPlayer {
 		// TODO: implement
 		return null;
 	}
-    
+
     @Override
     public int getXP() {
         return 0;
     }
-    
+
     @Override
     public void setXP(int xp) {
-    
+
     }
-    
+
     @Override
     public void removeXP(int xp) {
-    
+
     }
-    
+
     @Override
 	public void update(IData data) {
 		// TODO: implement
@@ -76,6 +76,10 @@ public class ServerPlayer implements IPlayer {
 
 	@Override
 	public void sendChat(String message) {
+        if (message.length() > MAX_CHAT_MESSAGE_LENGTH)
+        {
+            message = message.substring(0, MAX_CHAT_MESSAGE_LENGTH);
+        }
 		DedicatedServer.getServer().addChatMessage(new ChatComponentText(message));
 	}
 


### PR DESCRIPTION
Should fix the crash encountered in <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10207>, triggered by the missing LP jar generating a very long exception chat message.