### PR TITLE
Fix Implementation of `MCServer$MCCommand.compareTo(Object)`

### DIFF
--- a/src/main/java/minetweaker/mc1710/server/MCServer.java
+++ b/src/main/java/minetweaker/mc1710/server/MCServer.java
@@ -141,6 +141,11 @@ public class MCServer extends AbstractServer {
         public boolean isUsernameIndex(String[] var1, int var2) {
             return false;
         }
+
+        @Override
+        public int compareTo(Object o) {
+            return this.getCommandName().compareTo(((ICommand) o).getCommandName());
+        }
     }
 
     private class AddCommandAction implements IUndoableAction {

--- a/src/main/java/minetweaker/mc1710/server/MCServer.java
+++ b/src/main/java/minetweaker/mc1710/server/MCServer.java
@@ -141,11 +141,6 @@ public class MCServer extends AbstractServer {
         public boolean isUsernameIndex(String[] var1, int var2) {
             return false;
         }
-
-        @Override
-        public int compareTo(Object o) {
-            return 0;
-        }
     }
 
     private class AddCommandAction implements IUndoableAction {


### PR DESCRIPTION
This replicates the behaviour of `CommandBase`, using the `Comparable` implementation to sort the commands by name when auto-completing or using `/help`.
This was discovered using [HelpFixer](https://www.curseforge.com/minecraft/mc-mods/helpfixer):
```
[14:03:36] [Server thread/WARN] [FML/HelpFixer]: [HelpFixer] Command minetweaker incorrectly overrides compareTo: minetweaker.mc1710.server.MCServer$MCCommand
```