### PR TITLE
Remove bugged furnace warning

### DIFF
--- a/src/main/java/minetweaker/mc1710/furnace/MCFurnaceManager.java
+++ b/src/main/java/minetweaker/mc1710/furnace/MCFurnaceManager.java
@@ -52,7 +52,6 @@ public class MCFurnaceManager implements IFurnaceManager {
         }
 
         if (toRemove.isEmpty()) {
-            MineTweakerAPI.logWarning("No furnace recipes for " + output.toString());
         } else {
             MineTweakerAPI.apply(new RemoveAction(toRemove, toRemoveValues));
         }


### PR DESCRIPTION
Fixes issue #19

This warning shows up every time you load a new world and it is a bug because even with other furnace recipes existing for, lets say, leather, or even if I add my own furnace recipes for it, it will still print this warning, therefore it is bugged and useless.

The warning is practically useless too since you can just check NEI furnace recipes for an item.