### PR TITLE
Remove MT STUCK chat message

### DIFF
--- a/src/main/java/minetweaker/runtime/MTTweaker.java
+++ b/src/main/java/minetweaker/runtime/MTTweaker.java
@@ -26,8 +26,8 @@ import stanhebben.zenscript.compiler.IEnvironmentGlobal;
 import stanhebben.zenscript.parser.ParseException;
 
 /**
- * 
- * 
+ *
+ *
  * @author Stan Hebben
  */
 public class MTTweaker implements ITweaker {
@@ -172,7 +172,6 @@ public class MTTweaker implements ITweaker {
         }
 
         if (wereStuck.size() > 0) {
-            MineTweakerAPI.logWarning(Integer.toString(wereStuck.size()) + " modifications were stuck");
             for (IUndoableAction action : wereStuck) {
                 MineTweakerAPI.logInfo("Stuck: " + action.describe());
             }


### PR DESCRIPTION
this message always shows up when you have scripts that move around thaumcraft research, despite all the scripts working and the thaumcraft research moving, it displays the message, meaning that the message is innacurate, i am keeping it in the log file, just removing it from the ingame chat because it's redundant.