### PR TITLE
[Memory-opti:fix leak] Fix commands leaking server

### DIFF
--- a/src/main/java/minetweaker/mc1710/server/MCServer.java
+++ b/src/main/java/minetweaker/mc1710/server/MCServer.java
@@ -80,7 +80,7 @@ public class MCServer extends AbstractServer {
         }
     }
 
-    private class MCCommand implements ICommand {
+    private static class MCCommand implements ICommand {
 
         private final String name;
         private final String usage;
@@ -148,7 +148,7 @@ public class MCServer extends AbstractServer {
         }
     }
 
-    private class AddCommandAction implements IUndoableAction {
+    private static class AddCommandAction implements IUndoableAction {
 
         private final ICommand command;
 


### PR DESCRIPTION
because the commands were non-static inner classes of a class holding a world reference

<img width="583" height="242" alt="image" src="https://github.com/user-attachments/assets/e72664b8-6d9a-404f-8fb9-e3754f5e6586" />
